### PR TITLE
Fix for pyproject.toml and missing typehint in api folder

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,6 +4,44 @@ target-version = "py312"
 fix = true
 src = ["src"]
 
+[tool.ruff.lint]
+# Enable all linting rules.
+select = ["ALL"]
+# Ignore some of the most obnoxious linting errors.
+ignore = [
+  # Missing docstrings.
+  "D100",
+  "D103",
+  "D104",
+  "D105",
+  "D106",
+  "D107",
+  # Docstring whitespace.
+  "D203",
+  "D213",
+  # Docstring punctuation.
+  "D415",
+  # Docstring quotes.
+  "D301",
+  # Builtins.
+  "A",
+  # Print statements.
+  "T20",
+  # TODOs.
+  "TD002",
+  "TD003",
+  "FIX",
+  # Annotations.
+  "ANN101",
+  "ANN102",
+  # Conflict fix
+  "COM812",
+  "ISC001",
+  # star-import
+  "F403",
+]
+
+
 [tool.poetry]
 name = "bot-backend"
 version = "0.1.0"

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -4,5 +4,5 @@ app = FastAPI()
 
 
 @app.get("/")
-async def root():
+async def root() -> str:
     return "Hello, World"

--- a/bot/pyproject.toml
+++ b/bot/pyproject.toml
@@ -4,6 +4,44 @@ target-version = "py312"
 fix = true
 src = ["src"]
 
+[tool.ruff.lint]
+# Enable all linting rules.
+select = ["ALL"]
+# Ignore some of the most obnoxious linting errors.
+ignore = [
+  # Missing docstrings.
+  "D100",
+  "D103",
+  "D104",
+  "D105",
+  "D106",
+  "D107",
+  # Docstring whitespace.
+  "D203",
+  "D213",
+  # Docstring punctuation.
+  "D415",
+  # Docstring quotes.
+  "D301",
+  # Builtins.
+  "A",
+  # Print statements.
+  "T20",
+  # TODOs.
+  "TD002",
+  "TD003",
+  "FIX",
+  # Annotations.
+  "ANN101",
+  "ANN102",
+  # Conflict fix
+  "COM812",
+  "ISC001",
+  # star-import
+  "F403",
+]
+
+
 [tool.poetry]
 name = "exoquisite-exoplanets"
 version = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,6 @@ ignore = [
   # Conflict fix
   "COM812",
   "ISC001",
+  # star-import
+  "F403",
 ]


### PR DESCRIPTION
- **Mark star-import to be allowed by linter**
- **Include updated pyproject.toml**
- **Fix fastapi missing type-hint**
